### PR TITLE
Make WITH_STANDBY=true actually wire up the standby coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ export SEGMENT_ACCESS_PASSWORD="XXXXXXXX"
 | `INIT_ENV_ONLY` | false | Only configure OS, skip DB install and cluster init |
 | `INSTALL_DB_SOFTWARE` | true | Set false to skip RPM install (for reinit) |
 | `WITH_MIRROR` | false | Enable mirror segments |
-| `WITH_STANDBY` | false | Enable standby coordinator |
+| `WITH_STANDBY` | false | Enable standby coordinator. Requires a `##Standby hosts` block in `segmenthosts.conf` (see below). |
 | `MANUAL_REPO` | false | Skip auto YUM/APT repo configuration |
 | `COORDINATOR_PORT` | 5432 | Database port |
 | `DATA_DIRECTORY` | /data0/database/primary | Space-separated data directories |
@@ -178,6 +178,32 @@ Edit `segmenthosts.conf`:
 10.14.4.65 sdw4
 #Hashdata hosts end
 ```
+
+To deploy a **standby coordinator**, set `WITH_STANDBY="true"` in
+`deploycluster_parameter.sh` **and** add a `##Standby hosts` block
+between the segment hosts and `#Hashdata hosts end`:
+
+```
+##Define hosts used for Hashdata
+#Hashdata hosts begin
+##Coordinator hosts
+10.14.3.217 mdw
+##Segment hosts
+10.14.5.184 sdw1
+10.14.5.177 sdw2
+##Standby hosts
+10.14.5.250 smdw
+#Hashdata hosts end
+```
+
+Exactly one standby host is supported (this is a cbdb constraint —
+`gpinitstandby` only manages a single standby coordinator). The
+standby host receives the same OS-level prep as a segment
+(`gpadmin` user, RPM install, kernel params, `/etc/hosts` merge);
+`init_cluster.sh` then runs `gpinitstandby -a -s <standby-host>` on
+the coordinator after `gpstop -u`. With `WITH_STANDBY="false"` (the
+default) the `##Standby hosts` block is ignored, so it is safe to
+keep in the config across both deployment modes.
 
 #### 3. Start Deployment
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -158,7 +158,7 @@ export SEGMENT_ACCESS_KEYFILE="/root/.ssh/id_rsa"
 | `INIT_ENV_ONLY` | false | 仅初始化环境，跳过数据库安装和集群初始化 |
 | `INSTALL_DB_SOFTWARE` | true | 设为 false 跳过 RPM 安装（用于重新初始化）|
 | `WITH_MIRROR` | false | 启用 Mirror Segment |
-| `WITH_STANDBY` | false | 启用 Standby Coordinator |
+| `WITH_STANDBY` | false | 启用 Standby Coordinator。需在 `segmenthosts.conf` 中追加 `##Standby hosts` 区块（见下文）|
 | `MANUAL_REPO` | false | 跳过软件源自动配置 |
 | `COORDINATOR_PORT` | 5432 | 数据库端口 |
 | `DATA_DIRECTORY` | /data0/database/primary | 数据目录列表（空格分隔）|
@@ -177,6 +177,31 @@ export SEGMENT_ACCESS_KEYFILE="/root/.ssh/id_rsa"
 10.14.5.177 sdw2
 #Hashdata hosts end
 ```
+
+如需部署 **Standby Coordinator**，在 `deploycluster_parameter.sh`
+中设置 `WITH_STANDBY="true"`，**并** 在 `segment hosts` 与
+`#Hashdata hosts end` 之间追加 `##Standby hosts` 区块：
+
+```
+##Define hosts used for Hashdata
+#Hashdata hosts begin
+##Coordinator hosts
+10.14.3.217 mdw
+##Segment hosts
+10.14.5.184 sdw1
+10.14.5.177 sdw2
+##Standby hosts
+10.14.5.250 smdw
+#Hashdata hosts end
+```
+
+仅支持一个 Standby 主机（cbdb 限制：`gpinitstandby` 仅管理单一
+Standby Coordinator）。Standby 主机会与 Segment 主机一样接受 OS 层
+的初始化（gpadmin 用户、RPM 安装、内核参数、`/etc/hosts` 合并），
+随后 `init_cluster.sh` 会在 `gpstop -u` 之后于 Coordinator 上执行
+`gpinitstandby -a -s <standby-host>`。当 `WITH_STANDBY="false"`（默
+认值）时，`##Standby hosts` 区块会被忽略，因此可在两种部署模式中
+保留该区块。
 
 #### 3. 启动部署
 

--- a/deploycluster_parameter.sh
+++ b/deploycluster_parameter.sh
@@ -13,6 +13,10 @@ export INSTALL_DB_SOFTWARE="true"
 export INIT_ENV_ONLY="false"
 export INIT_CONFIGFILE="/tmp/gpinitsystem_config"
 export WITH_MIRROR="false"
+# When WITH_STANDBY=true, segmenthosts.conf must also include a
+# ##Standby hosts block declaring exactly one standby host (see
+# segmenthosts.conf for the format). Without that block this flag is
+# a no-op and the cluster is initialised without a standby coordinator.
 export WITH_STANDBY="false"
 export MANUAL_REPO="false"
 export TIMEZONE="Asia/Shanghai"

--- a/init_cluster.sh
+++ b/init_cluster.sh
@@ -82,12 +82,18 @@ MIRROR_DATA_DIRECTORY=(${MIRROR_DATA_DIRECTORY})
 EOF
 fi
 
-# Generate machine list
+# Generate machine list. The sed range is bounded at ##Standby hosts
+# (alternation falls through to #Hashdata hosts end when no standby
+# block is present, so the no-standby case is unchanged). Without the
+# bound, the awk picks up the literal "hosts" word from the
+# ##Standby hosts header line and feeds it to ping, FATALing
+# gpinitsystem with "Unknown host hosts"; the standby IP would also
+# leak in and gpinitsystem would create a gpseg-N on the standby host.
 if [ "$cluster_type" = "single" ]; then
   echo "${COORDINATOR_HOSTNAME}" > "${MACHINE_LIST_FILE}"
 elif [ "$cluster_type" = "multi" ]; then
-  sed -n '/##Segment hosts/,/#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | \
-    sed '1d;$d' | awk '{print $2}' > "${MACHINE_LIST_FILE}"
+  sed -n '/##Segment hosts/,/##Standby hosts\|#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | \
+    awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ {print $2}' > "${MACHINE_LIST_FILE}"
 else
   log_time "Error: DEPLOY_TYPE must be 'single' or 'multi', got: ${cluster_type}"
   exit 1
@@ -141,5 +147,30 @@ log_time "Finished setting up environment variables for ${ADMIN_USER}."
 # Reload configuration
 su "${ADMIN_USER}" -l -c "source ${CLOUDBERRY_BINARY_PATH}/${CLUSTER_ENV}; gpstop -u" || \
     log_time "Warning: gpstop -u failed."
+
+# Standby coordinator init. WITH_STANDBY=true means init_env.sh has
+# already provisioned the standby host (gpadmin user, RPM, /etc/hosts
+# merge, gpadmin SSH trust to all hosts). Now wire it up via
+# gpinitstandby on the coordinator. cbdb supports exactly one standby
+# coordinator so standby_hosts.txt is expected to carry one hostname.
+# init_env.sh's working_dir is a local var in that script's process;
+# rebuild it from SEGMENT_ACCESS_USER (same convention) so this script
+# stands alone.
+standby_hosts_file="/tmp/${SEGMENT_ACCESS_USER}/standby_hosts.txt"
+if [ "${WITH_STANDBY}" = "true" ] && [ -s "${standby_hosts_file}" ]; then
+  STANDBY_HOSTNAME=$(head -n1 "${standby_hosts_file}")
+  log_time "Initializing standby coordinator on ${STANDBY_HOSTNAME}..."
+  gpinit_stdby_exit=0
+  su "${ADMIN_USER}" -l -c "
+    export COORDINATOR_DATA_DIRECTORY=${COORDINATOR_DATA_DIRECTORY};
+    source ${CLOUDBERRY_BINARY_PATH}/${CLUSTER_ENV};
+    gpinitstandby -a -s ${STANDBY_HOSTNAME}
+  " || gpinit_stdby_exit=$?
+  if [ "${gpinit_stdby_exit}" -gt 1 ]; then
+    log_time "Warning: gpinitstandby exited ${gpinit_stdby_exit}; standby may not be configured."
+  else
+    log_time "Standby coordinator initialised on ${STANDBY_HOSTNAME}."
+  fi
+fi
 
 log_time "Finished cluster initialization."

--- a/init_env.sh
+++ b/init_env.sh
@@ -33,7 +33,18 @@ function config_hostsfile() {
   echo "##Coordinator hosts" >> "$temp_hosts"
   sed -n '/##Coordinator hosts/,/##Segment hosts/p' "${SCRIPT_DIR}/segmenthosts.conf" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' >> "$temp_hosts"
   echo "##Segment hosts" >> "$temp_hosts"
-  sed -n '/##Segment hosts/,/#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' >> "$temp_hosts"
+  # Bound the segment range at ##Standby hosts (if present) so a standby
+  # host declared in segmenthosts.conf is not grouped with segments.
+  sed -n '/##Segment hosts/,/##Standby hosts\|#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' >> "$temp_hosts"
+  # Optional ##Standby hosts block: when WITH_STANDBY=true the operator
+  # declares a single standby host between ##Standby hosts and
+  # #Hashdata hosts end. Distributed to every cluster host so cross-host
+  # name resolution works for gpinitstandby's base backup. Omitted when
+  # no standby block is present (default deploy is unchanged).
+  if grep -q '^##Standby hosts' "${SCRIPT_DIR}/segmenthosts.conf"; then
+    echo "##Standby hosts" >> "$temp_hosts"
+    sed -n '/##Standby hosts/,/#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' >> "$temp_hosts"
+  fi
   echo "#Hashdata hosts end" >> "$temp_hosts"
 
   cat "$temp_hosts" >> /etc/hosts
@@ -100,6 +111,65 @@ function init_segment() {
   wait
 
   log_time "Finished segment host initialization."
+}
+
+function copyfile_standby() {
+  # Mirror of copyfile_segment but for the standby host. Kept separate so
+  # the segment fan-out via multiscp.sh stays unchanged. WITH_STANDBY +
+  # non-empty standby_hosts.txt are gated by the caller.
+  log_time "Copying deployment files to standby host..."
+  local hosts_file="${working_dir}/standby_hosts.txt"
+  local access_opts
+  if [ "${SEGMENT_ACCESS_METHOD}" = "keyfile" ]; then
+    access_opts="-k ${SEGMENT_ACCESS_KEYFILE}"
+  else
+    access_opts="-p ${SEGMENT_ACCESS_PASSWORD}"
+  fi
+  local common_args="-v ${access_opts} -f ${hosts_file} -u ${SEGMENT_ACCESS_USER}"
+  bash "${SCRIPT_DIR}/multissh.sh" ${common_args} "rm -rf ${working_dir}; mkdir -p ${working_dir}"
+  local files_to_copy=(
+    "init_env_segment.sh"
+    "deploycluster_parameter.sh"
+    "common.sh"
+    "${working_dir}/hostsfile"
+    "/home/${ADMIN_USER}/.ssh/id_rsa.pub"
+    "${CLOUDBERRY_RPM}"
+  )
+  for f in "${files_to_copy[@]}"; do
+    local src="$f"
+    if [[ "$f" != /* ]] && [[ "$f" != "${working_dir}"/* ]]; then
+      src="${SCRIPT_DIR}/${f}"
+    fi
+    bash "${SCRIPT_DIR}/multiscp.sh" ${common_args} "${src}" "${working_dir}"
+  done
+  log_time "Finished copying files to standby host."
+}
+
+function init_standby() {
+  # Same shell as init_segment but iterates standby_hosts.txt (cbdb
+  # supports exactly one standby coordinator). The standby host gets the
+  # same OS-level prep as a segment via init_env_segment.sh — gpadmin
+  # user, /etc/hosts, RPM install, kernel params, /data dirs (created
+  # for both COORDINATOR_DIRECTORY and DATA_DIRECTORY by common.sh).
+  # gpinitstandby on the coordinator (in init_cluster.sh) wires up the
+  # cbdb-specific standby state on top of that prep.
+  log_time "Initializing standby coordinator host..."
+  local logfilename
+  logfilename="$(date +%Y%m%d_%H%M%S)"
+  local hosts_file="${working_dir}/standby_hosts.txt"
+  for i in $(cat "${hosts_file}"); do
+    local log_file="${working_dir}/init_env_standby_${i}_${logfilename}.log"
+    if [ "${SEGMENT_ACCESS_METHOD}" = "keyfile" ]; then
+      log_time "Initializing standby: ${i}"
+      ssh -n -q -i "${SEGMENT_ACCESS_KEYFILE}" "${SEGMENT_ACCESS_USER}@${i}" \
+        "bash -c 'sudo bash ${working_dir}/init_env_segment.sh ${i} ${working_dir} &> ${log_file}'" &
+    else
+      sshpass -p "${SEGMENT_ACCESS_PASSWORD}" ssh -n -q "${SEGMENT_ACCESS_USER}@${i}" \
+        "bash -c 'sudo bash ${working_dir}/init_env_segment.sh ${i} ${working_dir} &> ${log_file}'" &
+    fi
+  done
+  wait
+  log_time "Finished standby coordinator initialization."
 }
 
 # ==================== Main Execution ====================
@@ -175,29 +245,53 @@ if [ "$cluster_type" = "multi" ]; then
     chmod 600 "${SEGMENT_ACCESS_KEYFILE}"
   fi
 
-  # Extract segment hostnames
-  sed -n '/##Segment hosts/,/#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | \
+  # Extract segment hostnames (bounded — stop at ##Standby hosts so the
+  # standby host never lands in segment_hosts.txt; gpinitsystem would
+  # otherwise treat it as a segment).
+  sed -n '/##Segment hosts/,/##Standby hosts\|#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | \
     awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ {print $2}' > "${working_dir}/segment_hosts.txt"
+
+  # Extract standby hostname (zero or one host). Empty file means
+  # no-standby deploy (default); a non-empty file gates the optional
+  # standby provisioning + gpinitstandby step downstream.
+  sed -n '/##Standby hosts/,/#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | \
+    awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ {print $2}' > "${working_dir}/standby_hosts.txt"
 
   config_hostsfile
 
-  # Extend SSH config to include segment hosts
+  # Extend SSH config to include segment hosts (and the standby host if
+  # any — gpadmin needs SSH-keyless access to it for gpinitstandby's
+  # base-backup phase).
   seg_hosts=$(paste -sd' ' "${working_dir}/segment_hosts.txt")
-  sed -i "s/^Host .*/& ${seg_hosts}/" "/home/${ADMIN_USER}/.ssh/config"
+  standby_hosts=$(paste -sd' ' "${working_dir}/standby_hosts.txt" 2>/dev/null)
+  sed -i "s/^Host .*/& ${seg_hosts} ${standby_hosts}/" "/home/${ADMIN_USER}/.ssh/config"
 
-  # Add segment hosts to known_hosts for root
-  for i in $(cat "${working_dir}/segment_hosts.txt"); do
+  # Add segment + standby hosts to known_hosts for root. Concatenating
+  # the two files keeps the loop a no-op in the no-standby case
+  # (standby_hosts.txt is empty).
+  for i in $(cat "${working_dir}/segment_hosts.txt" "${working_dir}/standby_hosts.txt" 2>/dev/null); do
     ssh-keyscan "$i" >> ~/.ssh/known_hosts 2>/dev/null
   done
 
   copyfile_segment
   init_segment
 
+  # Standby coordinator gets the same OS-level prep as a segment
+  # (gpadmin user, RPM, kernel params, /etc/hosts, data dirs).
+  # gpinitstandby on the coordinator (in init_cluster.sh) expects all
+  # of that already in place.
+  if [ "${WITH_STANDBY}" = "true" ] && [ -s "${working_dir}/standby_hosts.txt" ]; then
+    copyfile_standby
+    init_standby
+  fi
+
   #Step 9: Setup no-password access for all nodes
   log_time "Step 9: Setup no-password access for all nodes..."
 
-  # Collect host keys for admin user (coordinator + all segments)
-  for i in $(cat "${working_dir}/segment_hosts.txt"); do
+  # Collect host keys for admin user (coordinator + all segments + standby).
+  # Concatenating both files keeps the loop a no-op in the no-standby
+  # case (standby_hosts.txt is empty).
+  for i in $(cat "${working_dir}/segment_hosts.txt" "${working_dir}/standby_hosts.txt" 2>/dev/null); do
     su "${ADMIN_USER}" -l -c "ssh-keyscan -t rsa,ecdsa,ed25519 ${i} >> ~/.ssh/known_hosts 2>/dev/null"
     ip_addr=$(getent hosts "$i" | awk '{print $1}')
     if [ -n "$ip_addr" ]; then

--- a/segmenthosts.conf
+++ b/segmenthosts.conf
@@ -7,4 +7,10 @@
 10.14.5.177 sdw2
 10.14.5.221 sdw3
 10.14.4.65 sdw4
+## Optional ##Standby hosts block — uncomment + populate when
+## WITH_STANDBY=true. Exactly one standby host (cbdb supports a single
+## standby coordinator). Omitting this block leaves WITH_STANDBY=true a
+## no-op, so the block must be present for the standby to be wired.
+##Standby hosts
+#10.14.5.250 smdw
 #Hashdata hosts end


### PR DESCRIPTION
## Problem

`deploycluster_parameter.sh` exports `WITH_STANDBY="false"` as if a true path existed, but no script in cbdbtools today consumes the variable — operators who set `WITH_STANDBY=true` silently get a primary-only cluster with no warning.

## What this PR does

Wires `WITH_STANDBY=true` end-to-end so it actually deploys a standby coordinator, and documents the required `segmenthosts.conf` format.

### `init_env.sh`
- `config_hostsfile` parses an optional `##Standby hosts` block in `segmenthosts.conf` and merges the standby line into the `/etc/hosts` payload distributed to every cluster host (so cross-host name resolution works for `gpinitstandby`'s base-backup phase).
- Extracts `standby_hosts.txt` alongside `segment_hosts.txt`; SSH config + `known_hosts` loops concatenate both files (no-op when no standby block is present).
- New `copyfile_standby` + `init_standby` helpers mirror the segment versions, gated on `WITH_STANDBY=true && -s standby_hosts.txt`. The standby host receives the same OS-level prep as a segment via the existing `init_env_segment.sh`; `gpinitstandby` on the coordinator wires up the cbdb-specific state on top.

### `init_cluster.sh`
- Bound the segment `sed` range at `##Standby hosts` (alternation falls through to `#Hashdata hosts end` when no standby block is present, so the no-standby case is unchanged). Without this bound, the `awk` picks up the literal "hosts" word from the `##Standby hosts` header line and feeds it to `ping`, FATAL-ing `gpinitsystem` with `"Unknown host hosts"`; the standby IP would also leak into `MACHINE_LIST_FILE` and `gpinitsystem` would create a `gpseg-N` on the standby host.
- After `gpstop -u`, when `WITH_STANDBY=true` and `standby_hosts.txt` is non-empty, runs `gpinitstandby -a -s \${STANDBY_HOSTNAME}` on the coordinator. cbdb supports exactly one standby coordinator so `STANDBY_HOSTNAME` is read from `head -n1 standby_hosts.txt`.

### Docs
- `segmenthosts.conf`: commented-out `##Standby hosts` example.
- `deploycluster_parameter.sh`: comment near `WITH_STANDBY` pointing at the required `segmenthosts.conf` block.
- `README.md` / `README_zh.md`: parameter table now flags the `segmenthosts.conf` dependency; the *Define Hosts* section shows a worked standby example with the cbdb single-standby constraint.

## Validation

End-to-end on **HashData Lightning 2.5.0** (multi-node, 1 coordinator + 1 standby + 2 segments):

- `gpinitsystem` returns exit 0; standby host correctly excluded from `MACHINE_LIST_FILE`.
- `gpinitstandby` logs:
  - `Adding standby coordinator to catalog...`
  - `Successfully created standby coordinator on preflight-lightning-...-standby-2`
- `gpstate -f` reports *Standby host active state*; `gp_segment_configuration` has a `content=-1` row with `role='m'` pointing at the standby host.
- A subsequent reboot-driven failover via `gpactivatestandby -a` succeeds; `pg_is_in_recovery() = false` on the new primary, data preserved.

## Backward compatibility

With **no** `##Standby hosts` block in `segmenthosts.conf`, both `init_env.sh` and `init_cluster.sh` produce byte-identical output to the pre-patch behaviour:
- The `sed` alternation `,/##Standby hosts\|#Hashdata hosts end/` falls through to the original `#Hashdata hosts end` terminator.
- `standby_hosts.txt` ends up empty, so the new `copyfile_standby` / `init_standby` / `gpinitstandby` paths are skipped entirely.

## Constraint surfaced in docs

cbdb's `gpinitstandby` only manages a single standby coordinator. The patch enforces this implicitly (`head -n1 standby_hosts.txt`) and the README change calls it out explicitly so operators don't try to declare two standby hosts and wonder why only one is wired.