### PR TITLE
Wire WITH_STANDBY into the Web UI

### DIFF
--- a/cluster_deploy_web.py
+++ b/cluster_deploy_web.py
@@ -151,6 +151,33 @@ def parse_segment_hosts(hosts_path=None):
     return segments
 
 
+def parse_standby_host(hosts_path=None):
+    """Parse the optional ##Standby hosts block; returns (ip, hostname) or ('', '')."""
+    if hosts_path is None:
+        hosts_path = HOSTS_FILE_PATH
+    if not os.path.isfile(hosts_path):
+        return ('', '')
+    in_section = False
+    with open(hosts_path, 'r') as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped.startswith('##Standby hosts'):
+                in_section = True
+                continue
+            if not in_section:
+                continue
+            if stripped.startswith('#') or not stripped:
+                if stripped.startswith('#'):
+                    break
+                continue
+            parts = stripped.split()
+            if len(parts) >= 2:
+                return (parts[0], parts[1])
+            if len(parts) == 1:
+                return (parts[0], '')
+    return ('', '')
+
+
 def detect_os_info():
     """Detect current operating system type and version."""
     info = {
@@ -293,7 +320,8 @@ def generate_config_file(params):
         '',
     ]
 
-    skip_keys = {'SEGMENT_IPS', 'SEGMENT_HOSTNAMES', 'SEGMENT_COUNT'}
+    skip_keys = {'SEGMENT_IPS', 'SEGMENT_HOSTNAMES', 'SEGMENT_COUNT',
+                 'STANDBY_IP', 'STANDBY_HOSTNAME'}
 
     for key, value in merged.items():
         if value and key not in skip_keys:
@@ -349,6 +377,15 @@ def generate_hosts_file(params):
     for i, ip in enumerate(ip_list):
         hostname = hostname_list[i] if i < len(hostname_list) else f'sdw{i + 1}'
         lines.append(f'{ip} {hostname}')
+
+    # Optional standby block. Consumed by init_env.sh + init_cluster.sh
+    # (PR #34) when WITH_STANDBY=true. cbdb supports exactly one standby.
+    if params.get('WITH_STANDBY') == 'true':
+        standby_ip = params.get('STANDBY_IP', '').strip()
+        standby_host = params.get('STANDBY_HOSTNAME', '').strip()
+        if standby_ip:
+            lines.append('##Standby hosts')
+            lines.append(f'{standby_ip} {standby_host or "smdw"}')
 
     lines.append('#Hashdata hosts end')
     return '\n'.join(lines) + '\n'
@@ -454,9 +491,11 @@ def index():
     """Main page - wizard interface."""
     file_config = parse_config_file()
     segment_hosts = parse_segment_hosts()
+    standby_host = parse_standby_host()
     return render_template('index.html',
                            file_config=file_config,
-                           segment_hosts=segment_hosts)
+                           segment_hosts=segment_hosts,
+                           standby_host=standby_host)
 
 
 @app.route('/detect_os')
@@ -569,6 +608,35 @@ def save_config():
                     segment_ips.append(ip)
                     segment_hostnames.append(hostname or f'sdw{len(segment_ips)}')
 
+    # Standby coordinator (multi-node only — single-node has no second host
+    # to host a standby; gpinitstandby would fail).
+    with_standby = request.form.get('WITH_STANDBY', 'false')
+    standby_ip = request.form.get('STANDBY_IP', '').strip()
+    standby_hostname = request.form.get('STANDBY_HOSTNAME', '').strip()
+    if with_standby == 'true':
+        if deploy_type != 'multi':
+            return jsonify({'success': False, 'message': 'Standby coordinator requires multi-node deployment'})
+        if not standby_ip:
+            return jsonify({'success': False, 'message': 'Standby IP is required when standby coordinator is enabled'})
+        if not validate_ip(standby_ip):
+            return jsonify({'success': False, 'message': f'Invalid standby IP: {standby_ip}'})
+        if standby_hostname and not validate_hostname(standby_hostname):
+            return jsonify({'success': False, 'message': f'Invalid standby hostname: {standby_hostname}'})
+        coord_ip = request.form.get('COORDINATOR_IP', '').strip()
+        coord_host = request.form.get('COORDINATOR_HOSTNAME', '').strip()
+        if standby_ip == coord_ip:
+            return jsonify({'success': False, 'message': 'Standby IP must differ from coordinator IP'})
+        if standby_hostname and standby_hostname == coord_host:
+            return jsonify({'success': False, 'message': 'Standby hostname must differ from coordinator hostname'})
+        if standby_ip in segment_ips:
+            return jsonify({'success': False, 'message': 'Standby IP must differ from segment IPs'})
+        if standby_hostname and standby_hostname in segment_hostnames:
+            return jsonify({'success': False, 'message': 'Standby hostname must differ from segment hostnames'})
+    else:
+        # Drop any leftover values so generate_hosts_file does not emit a block.
+        standby_ip = ''
+        standby_hostname = ''
+
     deploy_params = {
         'ADMIN_USER': request.form.get('ADMIN_USER', 'gpadmin').strip(),
         'ADMIN_USER_PASSWORD': request.form.get('ADMIN_USER_PASSWORD', ''),
@@ -600,6 +668,13 @@ def save_config():
         deploy_params['SEGMENT_ACCESS_USER'] = request.form.get('SEGMENT_ACCESS_USER', 'root').strip()
         deploy_params['SEGMENT_ACCESS_PASSWORD'] = request.form.get('SEGMENT_ACCESS_PASSWORD', '')
         deploy_params['SEGMENT_ACCESS_KEYFILE'] = request.form.get('SEGMENT_ACCESS_KEYFILE', '').strip()
+
+    # Stash standby info for generate_hosts_file (filtered out of
+    # deploycluster_parameter.sh by skip_keys; standby SSH access reuses
+    # SEGMENT_ACCESS_* — same machines, same credentials).
+    if with_standby == 'true' and standby_ip:
+        deploy_params['STANDBY_IP'] = standby_ip
+        deploy_params['STANDBY_HOSTNAME'] = standby_hostname or 'smdw'
 
     session['deploy_params'] = deploy_params
     session['deploy_type'] = deploy_type
@@ -634,6 +709,11 @@ def preview_config():
             hostname = hosts[i] if i < len(hosts) else f'sdw{i+1}'
             segments.append({'ip': ip, 'hostname': hostname})
 
+    standby = None
+    if params.get('WITH_STANDBY') == 'true' and params.get('STANDBY_IP'):
+        standby = {'ip': params.get('STANDBY_IP', ''),
+                   'hostname': params.get('STANDBY_HOSTNAME', '')}
+
     # Calculate segment count
     data_dirs = params.get('DATA_DIRECTORY', '/data0/database/primary').split()
     segs_per_host = len(data_dirs)
@@ -655,6 +735,7 @@ def preview_config():
         'db': db_info,
         'params': {k: v for k, v in params.items() if k != 'ADMIN_USER_PASSWORD' and k != 'SEGMENT_ACCESS_PASSWORD'},
         'segments': segments,
+        'standby': standby,
         'segs_per_host': segs_per_host,
         'total_segments': total_segments,
         'warnings': warnings,

--- a/templates/index.html
+++ b/templates/index.html
@@ -278,14 +278,18 @@
                 </div>
             </div>
 
-            <!-- Standby Coordinator (toggle) -->
-            <div class="toggle-section">
+            <!-- Standby Coordinator (toggle) — multi-node only -->
+            <div class="toggle-section" id="standby_section">
                 <label class="toggle-header">
-                    <input type="checkbox" id="chk_standby" {{ 'checked' if file_config.get('WITH_STANDBY') == 'true' else '' }}>
+                    <input type="checkbox" id="chk_standby" {{ 'checked' if file_config.get('WITH_STANDBY') == 'true' else '' }} onchange="onStandbyToggle()">
                     <span data-i18n="standby_coord">Standby Coordinator</span>
                 </label>
                 <div class="toggle-body" id="standby_body">
-                    <div class="hint" data-i18n="standby_hint">A standby coordinator will be created on one of the segment hosts for automatic failover.</div>
+                    <div class="fr">
+                        <div class="fg"><label data-i18n="standby_ip">Standby IP</label><input type="text" id="standby_ip" value="{{ standby_host[0] }}" placeholder="10.14.5.250"></div>
+                        <div class="fg"><label data-i18n="standby_host">Standby Hostname</label><input type="text" id="standby_host" value="{{ standby_host[1] }}" placeholder="smdw"></div>
+                    </div>
+                    <div class="hint" data-i18n="standby_hint">A dedicated standby host will be configured for coordinator failover. cbdb supports exactly one standby; SSH credentials reuse the segment access settings above.</div>
                 </div>
             </div>
 
@@ -364,6 +368,7 @@ document.addEventListener('DOMContentLoaded', () => {
     onDeployTypeChange();
     onSegAccessChange();
     onMirrorToggle();
+    onStandbyToggle();
     initSegTable();
     const pp = document.getElementById('pkg_path').value.trim();
     if (pp) validatePkg();
@@ -378,6 +383,14 @@ function onDeployTypeChange() {
     document.getElementById('dt_hint').dataset.i18n = hintKey;
     document.getElementById('sec_seghosts').style.display = deployType === 'multi' ? 'block' : 'none';
     document.getElementById('ph_seg').style.display = deployType === 'multi' ? 'block' : 'none';
+    // Standby coordinator only makes sense in multi-node mode (single-node
+    // has nowhere to host the standby; gpinitstandby would fail).
+    const standbySec = document.getElementById('standby_section');
+    standbySec.style.display = deployType === 'multi' ? 'block' : 'none';
+    if (deployType !== 'multi') {
+        const cb = document.getElementById('chk_standby');
+        if (cb.checked) { cb.checked = false; onStandbyToggle(); }
+    }
     configSaved = false; updateSaveState();
 }
 
@@ -396,7 +409,11 @@ function onMirrorToggle() {
 }
 
 // ==================== Standby Toggle ====================
-document.getElementById('chk_standby')?.addEventListener('change', () => { configSaved = false; updateSaveState(); });
+function onStandbyToggle() {
+    const on = document.getElementById('chk_standby').checked;
+    document.getElementById('standby_body').classList.toggle('open', on);
+    configSaved = false; updateSaveState();
+}
 
 // ==================== Segment Table ====================
 function initSegTable() {
@@ -533,7 +550,12 @@ function saveConfig() {
         fd.append('MIRROR_PORT_BASE', document.getElementById('m_port').value);
     }
 
-    fd.append('WITH_STANDBY', document.getElementById('chk_standby').checked ? 'true' : 'false');
+    const standbyOn = document.getElementById('chk_standby').checked && deployType === 'multi';
+    fd.append('WITH_STANDBY', standbyOn ? 'true' : 'false');
+    if (standbyOn) {
+        fd.append('STANDBY_IP', document.getElementById('standby_ip').value.trim());
+        fd.append('STANDBY_HOSTNAME', document.getElementById('standby_host').value.trim());
+    }
     fd.append('TIMEZONE', document.getElementById('opt_tz').value.trim());
     fd.append('MANUAL_REPO', document.getElementById('opt_skiprepo').checked ? 'true' : 'false');
     fd.append('INIT_ENV_ONLY', document.getElementById('opt_envonly').checked ? 'true' : 'false');
@@ -599,6 +621,19 @@ function validateStep2() {
         let has = false;
         document.querySelectorAll('#seg_tbody tr').forEach(tr => { if (tr.querySelector('.seg-ip').value.trim()) has = true; });
         if (!has) { alert('Add at least one segment host'); return false; }
+        if (document.getElementById('chk_standby').checked) {
+            const sIp = document.getElementById('standby_ip').value.trim();
+            const sHost = document.getElementById('standby_host').value.trim();
+            if (!sIp) { alert(I18N.standby_need_ip[curLang]); return false; }
+            const cIp = document.getElementById('c_ip').value.trim();
+            const cHost = document.getElementById('c_host').value.trim();
+            if (sIp === cIp) { alert(I18N.standby_dup_coord[curLang]); return false; }
+            if (sHost && sHost === cHost) { alert(I18N.standby_dup_coord[curLang]); return false; }
+            const segIps = Array.from(document.querySelectorAll('#seg_tbody .seg-ip')).map(el => el.value.trim()).filter(Boolean);
+            const segHosts2 = Array.from(document.querySelectorAll('#seg_tbody .seg-host')).map(el => el.value.trim()).filter(Boolean);
+            if (segIps.includes(sIp)) { alert(I18N.standby_dup_seg[curLang]); return false; }
+            if (sHost && segHosts2.includes(sHost)) { alert(I18N.standby_dup_seg[curLang]); return false; }
+        }
     }
     return true;
 }
@@ -629,6 +664,10 @@ function renderPreview(d) {
         h += '<div class="pv-section"><h3>Segment Hosts</h3><table class="pv-table"><thead><tr><th>#</th><th>IP</th><th>Hostname</th></tr></thead><tbody>';
         d.segments.forEach((s,i) => { h += '<tr><td>'+(i+1)+'</td><td>'+esc(s.ip)+'</td><td>'+esc(s.hostname)+'</td></tr>'; });
         h += '</tbody></table></div>';
+    }
+
+    if (d.standby) {
+        h += pvSec('Standby Coordinator', [['IP', d.standby.ip||'-'], ['Hostname', d.standby.hostname||'-']]);
     }
 
     h += pvSec('Options', [['Admin User', p.ADMIN_USER||'gpadmin'], ['Mirror', p.WITH_MIRROR==='true'?'Enabled':'Disabled'], ['Standby', p.WITH_STANDBY==='true'?'Enabled':'Disabled'], ['Timezone', p.TIMEZONE||'Asia/Shanghai']].concat(
@@ -778,7 +817,12 @@ const I18N = {
     mirror_port: { en: 'Mirror Port Base', zh: 'Mirror 起始端口' },
     mirror_hint: { en: 'Mirror segments provide redundancy. Each primary segment will have a corresponding mirror.', zh: 'Mirror 提供数据冗余，每个主 Segment 会有一个对应的 Mirror 副本。' },
     standby_coord: { en: 'Standby Coordinator', zh: 'Standby Coordinator' },
-    standby_hint: { en: 'A standby coordinator will be created on one of the segment hosts for automatic failover.', zh: '将在一台 Segment 主机上创建 Standby Coordinator，用于自动故障切换。' },
+    standby_hint: { en: 'A dedicated standby host will be configured for coordinator failover. cbdb supports exactly one standby; SSH credentials reuse the segment access settings above.', zh: '将单独配置一台 Standby 主机用于 Coordinator 故障切换。cbdb 仅支持单 Standby；SSH 凭据复用上方 Segment 的访问设置。' },
+    standby_ip: { en: 'Standby IP', zh: 'Standby IP' },
+    standby_host: { en: 'Standby Hostname', zh: 'Standby 主机名' },
+    standby_need_ip: { en: 'Standby IP is required when standby is enabled', zh: '启用 Standby 时必须填写 Standby IP' },
+    standby_dup_coord: { en: 'Standby must differ from coordinator', zh: 'Standby 不能与 Coordinator 相同' },
+    standby_dup_seg: { en: 'Standby must differ from segment hosts', zh: 'Standby 不能与 Segment 主机相同' },
     options: { en: 'Options', zh: '选项' }, timezone: { en: 'Timezone', zh: '时区' },
     skip_repo: { en: 'Skip Repo Config', zh: '跳过软件源配置' },
     env_only: { en: 'Init Environment Only', zh: '仅初始化环境' },


### PR DESCRIPTION
## Problem

PR #34 made \`WITH_STANDBY=true\` functional end-to-end via a \`##Standby hosts\` block in \`segmenthosts.conf\`. The CLI path now wires up a standby coordinator correctly. The Web UI did not — \`templates/index.html\` had a "Standby Coordinator" toggle, but:

- No IP/hostname inputs to declare the standby host.
- \`generate_hosts_file()\` never emitted a \`##Standby hosts\` block.
- The hint text said "on one of the segment hosts," contradicting the actual contract (a dedicated host).
- \`parse_segment_hosts()\` had no symmetric standby parser, so reloads dropped the block.

Net effect: checking the UI box silently produced a primary-only cluster — the same bug PR #34 fixed for the CLI.

## What this PR does

### Backend (\`cluster_deploy_web.py\`)
- **\`parse_standby_host()\`**: symmetric reader for the \`##Standby hosts\` block. Returns \`('', '')\` when the block is absent or the IP line is commented (default-shipped state), so existing \`segmenthosts.conf\` files still parse cleanly.
- **\`generate_hosts_file()\`**: emits \`##Standby hosts\\n<ip> <host>\` before \`#Hashdata hosts end\` when \`WITH_STANDBY=true\` and \`STANDBY_IP\` is set. **Output is byte-identical to the prior behaviour when standby is off** (asserted in smoke test).
- **\`save_config\` validation**: standby requires multi-node; IP must be well-formed; IP/hostname must differ from coordinator and from every segment.
- **\`skip_keys\`**: \`STANDBY_IP\` / \`STANDBY_HOSTNAME\` are filtered out of \`deploycluster_parameter.sh\` (same convention as \`SEGMENT_IPS\`) — they only land in \`segmenthosts.conf\`.
- **\`/preview_config\`**: returns \`standby: {ip, hostname}\` so the confirmation step can show it.
- **\`/\` route**: passes the parsed standby tuple to the template for prefill on page load.

### Frontend (\`templates/index.html\`)
- Standby toggle now reveals **IP + Hostname inputs** when checked, mirroring the existing Mirror toggle pattern (\`onStandbyToggle()\` + \`.open\` class, initialised in \`DOMContentLoaded\`).
- **\`onDeployTypeChange\`** hides the standby section and force-unchecks it in **single-node mode** — single has nowhere to host a standby; \`gpinitstandby\` would fail.
- Hint text rewritten to match PR #34's contract: a dedicated standby host using the same \`SEGMENT_ACCESS_*\` credentials as the segments (no second credential set).
- Save-time validation in the browser (empty IP, collision with coordinator/segment) as a first line of defence; backend re-validates.
- Preview page shows a "Standby Coordinator" section when enabled.
- Five new i18n keys (\`standby_ip\` / \`standby_host\` labels + three validation messages), EN + ZH.

## Validation

- \`pytest test_web.py\` — **61/61 pass** (no regressions).
- New smoke checks (run locally):
  - \`parse_standby_host\` — returns empty for the default shipped \`segmenthosts.conf\` (IP commented), correctly extracts \`('10.14.5.250', 'smdw')\` once enabled.
  - \`generate_hosts_file\` — produces a valid \`##Standby hosts\` block matching PR #34's parser when standby is on; byte-identical no-standby output otherwise (asserted).
  - \`save_config\` — rejects single + standby, missing IP, IP=coordinator; accepts a valid multi-node config.
  - \`/preview_config\` — carries \`{ip, hostname}\`.

## End-to-end flow after this PR

\`Check toggle\` → \`fill IP/host\` → save writes \`##Standby hosts\` block to \`segmenthosts.conf\` and \`WITH_STANDBY=true\` to \`deploycluster_parameter.sh\` → PR #34's downstream pipeline (\`init_env.sh\` provisions standby host like a segment, \`init_cluster.sh\` runs \`gpinitstandby\` after \`gpstop -u\`) takes over unchanged.

## Backward compatibility

- Standby toggle off → \`generate_hosts_file\` produces the same output as before (asserted).
- Existing \`segmenthosts.conf\` files without a \`##Standby hosts\` block parse the same as before.
- No new exported variables in \`deploycluster_parameter.sh\`; standby info lives only in \`segmenthosts.conf\`, matching the CLI convention.