### PR TITLE
Fix two latent bugs surfaced during PR #34 e2e on fresh Rocky 9

### DIFF
--- a/init_cluster.sh
+++ b/init_cluster.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VARS_FILE="deploycluster_parameter.sh"
 
 source "${SCRIPT_DIR}/${VARS_FILE}"
+source "${SCRIPT_DIR}/common.sh"
 
 if [ "${1}" = "single" ] || [ "${1}" = "multi" ]; then
   cluster_type="${1}"

--- a/init_env.sh
+++ b/init_env.sh
@@ -259,12 +259,21 @@ if [ "$cluster_type" = "multi" ]; then
 
   config_hostsfile
 
-  # Extend SSH config to include segment hosts (and the standby host if
-  # any — gpadmin needs SSH-keyless access to it for gpinitstandby's
-  # base-backup phase).
+  # Extend SSH config to include segment hosts + their IPs (and the
+  # standby host + its IP if any). gpadmin needs SSH-keyless access to
+  # them for gpinitstandby's base-backup phase, AND tools like
+  # gpinitsystem probe segments by IP — without IP entries in the Host
+  # line, StrictHostKeyChecking falls back to the system default (ask)
+  # and BatchMode-yes SSH fails on first connect even when known_hosts
+  # is populated. Pre-baked images often paper over this; fresh VMs do
+  # not.
   seg_hosts=$(paste -sd' ' "${working_dir}/segment_hosts.txt")
   standby_hosts=$(paste -sd' ' "${working_dir}/standby_hosts.txt" 2>/dev/null)
-  sed -i "s/^Host .*/& ${seg_hosts} ${standby_hosts}/" "/home/${ADMIN_USER}/.ssh/config"
+  seg_ips=$(sed -n '/##Segment hosts/,/##Standby hosts\|#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | \
+    awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ {print $1}' | paste -sd' ')
+  standby_ips=$(sed -n '/##Standby hosts/,/#Hashdata hosts end/p' "${SCRIPT_DIR}/segmenthosts.conf" | \
+    awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ {print $1}' | paste -sd' ')
+  sed -i "s/^Host .*/& ${seg_hosts} ${standby_hosts} ${seg_ips} ${standby_ips}/" "/home/${ADMIN_USER}/.ssh/config"
 
   # Add segment + standby hosts to known_hosts for root. Concatenating
   # the two files keeps the loop a no-op in the no-standby case


### PR DESCRIPTION
## Why this PR

Both issues were observed deploying cbdbtools \`dev\` tip on a brand-new Rocky 9.5 ZStack VM during PR #34 / #35 e2e validation. They are **pre-existing, not introduced by PR #34**, but PR #34's standby block made the first one louder and the second one became a hard blocker on un-baked VMs.

Preflight's pre-baked Rocky-9.5 image masks both. They only surface on a clean install.

---

## Fix 1 — \`init_cluster.sh\` never sourced \`common.sh\`

\`init_cluster.sh\` sources \`deploycluster_parameter.sh\` but not \`common.sh\`, where \`log_time()\` is defined. Every \`log_time\` call in the file therefore prints \`init_cluster.sh: line N: log_time: command not found\` to stderr.

- Pre-PR #34: ~5 stderr lines per run, mostly ignored.
- Post-PR #34: ~10 stderr lines (the standby block adds 5 more), which made the deploy log look broken even on successful runs.

\`\`\`diff
 source \"\${SCRIPT_DIR}/\${VARS_FILE}\"
+source \"\${SCRIPT_DIR}/common.sh\"
\`\`\`

Matches what \`init_env.sh\` and \`deploycluster.sh\` already do.

## Fix 2 — gpadmin SSH config \`Host\` line missed segment + standby IPs

\`init_env.sh\` writes:

\`\`\`
Host mdw 10.14.8.162 localhost sdw1 sdw2 smdw
    StrictHostKeyChecking no
    LogLevel ERROR
\`\`\`

The Host line covers segment **hostnames** but not segment **IPs**. \`gpinitsystem\` (and other DB tools) probe segments by **IP**, not by hostname. With BatchMode=yes SSH and no IP entry in the Host pattern, \`StrictHostKeyChecking\` falls back to the system default (\`ask\`); on a brand-new VM that's a hard fail even when \`known_hosts\` has a matching entry.

On the test VM this manifested as:

\`\`\`
Host key verification failed.
/usr/local/hashdata-lightning-2.5.0/bin/gpinitsystem: line 746: [: -lt: unary operator expected
Host key verification failed.
20260430:14:08:20:022078 gpinitsystem:mdw:gpadmin-[WARN]:-Postgres version does not match. [postgres (Apache Cloudberry) 2.5.0 build 133298 != ]
20260430:14:08:20:022078 gpinitsystem:mdw:gpadmin-Postgres version does not match Script Exiting!
\`\`\`

The \`!=\` comparison's empty right-hand-side is \`gpinitsystem\`'s failed \`ssh ... postgres --gp-version\` probe being interpreted as "no version returned", which produces the misleading version-mismatch error.

Fix: extract segment + standby IPs from \`segmenthosts.conf\` using the same sed range as the existing extraction, then include them on the Host line.

\`\`\`diff
   seg_hosts=\$(paste -sd' ' \"\${working_dir}/segment_hosts.txt\")
   standby_hosts=\$(paste -sd' ' \"\${working_dir}/standby_hosts.txt\" 2>/dev/null)
-  sed -i \"s/^Host .*/& \${seg_hosts} \${standby_hosts}/\" \"...\"
+  seg_ips=\$(sed -n '/##Segment hosts/,/##Standby hosts\\\\|#Hashdata hosts end/p' \"\${SCRIPT_DIR}/segmenthosts.conf\" | \\
+    awk '/^[0-9]+\\\\.[0-9]+\\\\.[0-9]+\\\\.[0-9]+/ {print \$1}' | paste -sd' ')
+  standby_ips=\$(sed -n '/##Standby hosts/,/#Hashdata hosts end/p' \"\${SCRIPT_DIR}/segmenthosts.conf\" | \\
+    awk '/^[0-9]+\\\\.[0-9]+\\\\.[0-9]+\\\\.[0-9]+/ {print \$1}' | paste -sd' ')
+  sed -i \"s/^Host .*/& \${seg_hosts} \${standby_hosts} \${seg_ips} \${standby_ips}/\" \"...\"
\`\`\`

After the fix the Host line becomes:

\`\`\`
Host mdw 10.14.8.162 localhost sdw1 sdw2 smdw 10.14.8.178 10.14.8.8 10.14.8.248
\`\`\`

\`StrictHostKeyChecking=no\` now covers IP-keyed connects too.

---

## Validation

- **\`bash -n\`** clean on both files.
- **IP extraction smoke test**:
  - With \`##Standby hosts\` block: \`seg_ips=10.14.5.184 10.14.5.177 10.14.4.65\`, \`standby_ips=10.14.5.250\`
  - Without standby block: \`seg_ips=10.14.5.184 10.14.5.177\`, \`standby_ips=\` (empty — correct, the no-standby case is unchanged because the empty variable in the sed substitution adds nothing)
- **\`pytest test_web.py\`**: 61/61 pass (no UI regressions; PR #35's logic is untouched here).
- **End-to-end on ZStack** with the same 4-VM topology used to validate PR #34: \`gpinitsystem\` succeeds on first try, \`gpinitstandby\` succeeds, \`gpstate -f\` reports \`Standby host passive\` with \`WAL Sender State: streaming\`, \`Sync state: sync\`. Without these fixes the same 4-VM run failed deterministically at \`gpinitsystem\`'s "Checking new segment hosts" phase.

## Backward compatibility

- \`source common.sh\` is purely additive; \`common.sh\` is already shipped and side-effect-free at source-time.
- Adding IPs to the Host line is a no-op when no standby block exists (the standby_ips variable expands to empty).
- No new exported variables, no segmenthosts.conf format change, no behaviour change for pre-baked images that already had SSH set up correctly.