### PR TITLE
Document Web UI standby toggle in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Then open `http://<coordinator-ip>:5000` in a browser.
 The Web UI is a 4-step wizard:
 
 1. **Environment** - Select OS type (auto-detected), deployment mode (single/multi), and database package. You can either enter a path to a package already on the server, or **upload a package directly from your browser** via drag-and-drop (with real-time progress)
-2. **Configuration** - Set admin user, coordinator info, segment hosts (multi-node), data directories, and advanced options. Click **Save Configuration** before proceeding
-3. **Preview** - Review complete deployment summary with warnings for missing mirrors/standby
+2. **Configuration** - Set admin user, coordinator info, segment hosts (multi-node), data directories, and advanced options. Toggle **Mirror Segments** for redundancy, and toggle **Standby Coordinator** to deploy a standby host (multi-node only — checking the box reveals IP + hostname inputs; cbdb supports exactly one standby; the standby reuses the same SSH credentials as segments). Click **Save Configuration** before proceeding
+3. **Preview** - Review complete deployment summary, including the standby host when enabled, with warnings for missing mirrors/standby
 4. **Deploy** - Real-time log streaming with phase progress indicators. Shows connection info on success
 
 ### Command-line Deployment

--- a/README_zh.md
+++ b/README_zh.md
@@ -112,8 +112,8 @@ bash start_web.sh
 Web UI 采用 4 步向导模式：
 
 1. **环境配置** - 选择操作系统（自动检测）、部署模式（单机/多机）、数据库安装包。支持从浏览器拖拽上传安装包（实时显示进度）
-2. **集群配置** - 设置管理员用户、Coordinator 信息、Segment 主机（多机模式）、数据目录等。点击**保存配置**后继续
-3. **确认部署** - 查看完整部署配置摘要，包含 Mirror/Standby 未启用等警告信息
+2. **集群配置** - 设置管理员用户、Coordinator 信息、Segment 主机（多机模式）、数据目录等。可勾选 **Mirror Segments** 启用 Mirror 副本；可勾选 **Standby Coordinator** 部署 Standby 主机（仅多机模式 — 勾选后展开 IP + 主机名输入；cbdb 仅支持单 Standby；Standby 复用 Segment 的 SSH 凭据）。点击**保存配置**后继续
+3. **确认部署** - 查看完整部署配置摘要，启用 Standby 时会展示 Standby 主机信息；包含 Mirror/Standby 未启用等警告信息
 4. **执行部署** - 实时日志流输出，带阶段进度指示器。成功后显示连接信息
 
 界面支持中英文切换（右上角切换按钮）。


### PR DESCRIPTION
## Why

PR #35 added the Web UI standby toggle (Mirror-style — checkbox reveals IP/hostname inputs, hidden in single-node mode, validates against coord/segment collisions). PR #34 already updated the README's CLI flow. But the README's Web UI 4-step wizard description still only said \"advanced options\" — operators reading the docs had no signal that standby is configurable from the UI.

This PR brings the UI doc to parity with the CLI doc.

## Changes

- **Step 2 (Configuration)** in both README.md and README_zh.md now mentions:
  - Both Mirror and Standby toggles
  - The multi-node-only constraint for standby
  - The IP + hostname inputs that appear when checked
  - The cbdb single-standby limit
  - SSH credential reuse with segments (no second credential set)
- **Step 3 (Preview)** mentions the standby host appears in the summary when enabled.

EN + ZH kept in lockstep, matching the existing convention for this repo.

## Out of scope (follow-up)

A separate PR will add real UI screenshots under \`docs/screenshots/\` and weave them into the README to make the wizard a step-by-step visual walkthrough for customers. This text-only update is shippable on its own.